### PR TITLE
resource-schemaをテストに追加した

### DIFF
--- a/lib/cases/test_resources.js
+++ b/lib/cases/test_resources.js
@@ -9,6 +9,9 @@
 'use strict'
 
 const co = require('co')
+const aschema = require('aschema')
+const { ok } = require('assert')
+const { ResourceSchema } = require('clay-schemas')
 
 /** @lends testResources */
 function testResources (driver, options = {}) {
@@ -20,6 +23,14 @@ function testResources (driver, options = {}) {
       at: new Date()
     })
 
+    let resources = yield driver.resources()
+    ok(resources.length > 0)
+    let schema = aschema(ResourceSchema)
+    for (let resource of resources) {
+      schema.validateToThrow(resource)
+    }
+
+    yield driver.drop()
   })
 }
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,7 +1,7 @@
 /**
  * Tests for ClayDB drivers
  * @module clay-driver-tests
- * @version 1.1.1
+ * @version 1.1.2
  */
 
 'use strict'

--- a/package.json
+++ b/package.json
@@ -23,7 +23,9 @@
   },
   "homepage": "https://github.com/realglobe-Inc/clay-driver-tests#readme",
   "dependencies": {
-    "clay-constants": "^1.3.1",
+    "aschema": "^2.0.4",
+    "clay-constants": "^2.4.1",
+    "clay-schemas": "^2.0.2",
     "co": "^4.6.0",
     "colorprint": "^4.1.0"
   },
@@ -36,7 +38,7 @@
     "ape-tasking": "^4.0.9",
     "ape-tmpl": "^5.0.20",
     "ape-updating": "^4.1.0",
-    "clay-driver-memory": "^2.1.3",
+    "clay-driver-memory": "^3.0.3",
     "coz": "^6.0.20",
     "injectmock": "^2.0.0",
     "stringcase": "^3.2.1",


### PR DESCRIPTION
`driver.resrouces()`メソッドで返ってくるresourceの形式がclay-schemasに合致しているかどうかのテストを追加した